### PR TITLE
Added support for wiring nodes colorisation

### DIFF
--- a/Assets/Klak/Wiring/Editor/Patcher/GraphGUI.cs
+++ b/Assets/Klak/Wiring/Editor/Patcher/GraphGUI.cs
@@ -253,6 +253,13 @@ namespace Klak.Wiring.Patcher
                 menu.AddItem(new GUIContent("Duplicate"), false, ContextMenuCallback, "Duplicate");
                 menu.AddSeparator("");
                 menu.AddItem(new GUIContent("Delete"), false, ContextMenuCallback, "Delete");
+
+                menu.AddSeparator("");
+                var colors = Enum.GetValues(typeof(Graphs.Styles.Color)).Cast<Graphs.Styles.Color>().Distinct();
+                foreach (var color in colors)
+                {
+                    menu.AddItem(new GUIContent("Color/" + color), false, ContextMenuColorCallback, color);
+                }
 			}
 			else if (edgeGUI.edgeSelection.Count != 0)
             {
@@ -275,6 +282,16 @@ namespace Klak.Wiring.Patcher
         void ContextMenuCallback(object data)
         {
             m_Host.SendEvent(EditorGUIUtility.CommandEvent((string)data));
+        }
+
+        void ContextMenuColorCallback(object data)
+        {
+            var newColor = (Graphs.Styles.Color)data;
+
+            foreach (Node node in selection)
+            {
+                node.SetColor(newColor);
+            }
         }
 
         void CreateMenuItemCallback(object data)

--- a/Assets/Klak/Wiring/Editor/Patcher/Node.cs
+++ b/Assets/Klak/Wiring/Editor/Patcher/Node.cs
@@ -57,6 +57,17 @@ namespace Klak.Wiring.Patcher
             get { return _runtimeInstance != null; }
         }
 
+        // Set color of node
+        public void SetColor(Graphs.Styles.Color newColor)
+        {
+            if (color == newColor) return;
+
+            color = newColor;
+            _serializedObject.Update();
+            _serializedColor.intValue = (int)newColor;
+            _serializedObject.ApplyModifiedProperties();
+        }
+
         #endregion
 
         #region Overridden virtual methods
@@ -98,6 +109,7 @@ namespace Klak.Wiring.Patcher
         // Serialized property accessor
         SerializedObject _serializedObject;
         SerializedProperty _serializedPosition;
+        SerializedProperty _serializedColor;
 
         // Initializer (called from the Create method)
         void Initialize(Wiring.NodeBase runtimeInstance)
@@ -108,10 +120,12 @@ namespace Klak.Wiring.Patcher
             _runtimeInstance = runtimeInstance;
             _serializedObject = new UnityEditor.SerializedObject(runtimeInstance);
             _serializedPosition = _serializedObject.FindProperty("_wiringNodePosition");
+            _serializedColor = _serializedObject.FindProperty("_wiringNodeColor");
 
             // Basic information
             name = runtimeInstance.GetInstanceID().ToString();
             position = new Rect(_serializedPosition.vector2Value, Vector2.zero);
+            color = (Graphs.Styles.Color)_serializedColor.intValue;
 
             // Slot initialization
             PopulateSlots();

--- a/Assets/Klak/Wiring/Runtime/System/NodeBase.cs
+++ b/Assets/Klak/Wiring/Runtime/System/NodeBase.cs
@@ -51,6 +51,9 @@ namespace Klak.Wiring
         [SerializeField, HideInInspector]
         Vector2 _wiringNodePosition = uninitializedNodePosition;
 
+        [SerializeField, HideInInspector]
+        int _wiringNodeColor = uninitializedNodeColor;
+
         [Serializable]
         public class VoidEvent : UnityEvent {}
 
@@ -68,6 +71,10 @@ namespace Klak.Wiring
 
         static public Vector2 uninitializedNodePosition {
             get { return new Vector2(-1000, -1000); }
+        }
+
+        static public int uninitializedNodeColor {
+            get { return 0; }
         }
     }
 }


### PR DESCRIPTION
This code adds support for changing color of wiring nodes. Color is stored in a hidden SerializedProperty of NodeBase. It is very useful to colorise graph when it has a lot of nodes.
![unity 5 5 0f3 64bit - wiring unity - klak 2017-02-19 18-43-18](https://cloud.githubusercontent.com/assets/7161820/23103884/e666b5c2-f6d3-11e6-8ab0-441ccbc13349.png)
