### PR TITLE
Added support for wiring nodes colorisation on upm

### DIFF
--- a/Wiring/Editor/Patcher/GraphGUI.cs
+++ b/Wiring/Editor/Patcher/GraphGUI.cs
@@ -253,6 +253,13 @@ namespace Klak.Wiring.Patcher
                 menu.AddItem(new GUIContent("Duplicate"), false, ContextMenuCallback, "Duplicate");
                 menu.AddSeparator("");
                 menu.AddItem(new GUIContent("Delete"), false, ContextMenuCallback, "Delete");
+
+                menu.AddSeparator("");
+                var colors = Enum.GetValues(typeof(Graphs.Styles.Color)).Cast<Graphs.Styles.Color>().Distinct();
+                foreach (var color in colors)
+                {
+                    menu.AddItem(new GUIContent("Color/" + color), false, ContextMenuColorCallback, color);
+                }
 			}
 			else if (edgeGUI.edgeSelection.Count != 0)
             {
@@ -275,6 +282,16 @@ namespace Klak.Wiring.Patcher
         void ContextMenuCallback(object data)
         {
             m_Host.SendEvent(EditorGUIUtility.CommandEvent((string)data));
+        }
+
+        void ContextMenuColorCallback(object data)
+        {
+            var newColor = (Graphs.Styles.Color)data;
+
+            foreach (Node node in selection)
+            {
+                node.SetColor(newColor);
+            }
         }
 
         void CreateMenuItemCallback(object data)

--- a/Wiring/Editor/Patcher/Node.cs
+++ b/Wiring/Editor/Patcher/Node.cs
@@ -57,6 +57,17 @@ namespace Klak.Wiring.Patcher
             get { return _runtimeInstance != null; }
         }
 
+        // Set color of node
+        public void SetColor(Graphs.Styles.Color newColor)
+        {
+            if (color == newColor) return;
+
+            color = newColor;
+            _serializedObject.Update();
+            _serializedColor.intValue = (int)newColor;
+            _serializedObject.ApplyModifiedProperties();
+        }
+
         #endregion
 
         #region Overridden virtual methods
@@ -98,6 +109,7 @@ namespace Klak.Wiring.Patcher
         // Serialized property accessor
         SerializedObject _serializedObject;
         SerializedProperty _serializedPosition;
+        SerializedProperty _serializedColor;
 
         // Initializer (called from the Create method)
         void Initialize(Wiring.NodeBase runtimeInstance)
@@ -108,10 +120,12 @@ namespace Klak.Wiring.Patcher
             _runtimeInstance = runtimeInstance;
             _serializedObject = new UnityEditor.SerializedObject(runtimeInstance);
             _serializedPosition = _serializedObject.FindProperty("_wiringNodePosition");
+            _serializedColor = _serializedObject.FindProperty("_wiringNodeColor");
 
             // Basic information
             name = runtimeInstance.GetInstanceID().ToString();
             position = new Rect(_serializedPosition.vector2Value, Vector2.zero);
+            color = (Graphs.Styles.Color)_serializedColor.intValue;
 
             // Slot initialization
             PopulateSlots();

--- a/Wiring/Runtime/System/NodeBase.cs
+++ b/Wiring/Runtime/System/NodeBase.cs
@@ -51,6 +51,9 @@ namespace Klak.Wiring
         [SerializeField, HideInInspector]
         Vector2 _wiringNodePosition = uninitializedNodePosition;
 
+        [SerializeField, HideInInspector]
+        int _wiringNodeColor = uninitializedNodeColor;
+
         [Serializable]
         public class VoidEvent : UnityEvent {}
 
@@ -68,6 +71,10 @@ namespace Klak.Wiring
 
         static public Vector2 uninitializedNodePosition {
             get { return new Vector2(-1000, -1000); }
+        }
+
+        static public int uninitializedNodeColor {
+            get { return 0; }
         }
     }
 }


### PR DESCRIPTION
Colorisation for nodes. Does not break previous savings. The same as [https://github.com/keijiro/Klak/pull/23](23) but for upm branch
![e666b5c2-f6d3-11e6-8ab0-441ccbc13349](https://user-images.githubusercontent.com/7161820/52131233-53b1a880-264d-11e9-808a-21938d90f48f.png)
